### PR TITLE
Lil update

### DIFF
--- a/fail2ban_analyse_wrapper.sh
+++ b/fail2ban_analyse_wrapper.sh
@@ -16,6 +16,12 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+# Checking if the user running the script is root
+if [ "$EUID" -ne 0 ]
+  then echo "ERROR: Please run this script either as root or via sudo/doas"
+  exit
+fi
+
 echo "-------------------------------------------------------------------------------------------"
 echo "Fail2ban log analysis and visualisation wrapper process started"
 

--- a/scripts/fail2ban_analyse.py
+++ b/scripts/fail2ban_analyse.py
@@ -304,7 +304,7 @@ if len(sys.argv) < 4:
   attacker_info_filename = filename_stub+"_raw_attacker_info.txt"
   f = open(attacker_info_filename, "w")
   for line in IP_unique:
-    attacker_ele = subprocess.check_output("curl ipinfo.io/%s/geo" % line, shell=True)
+    attacker_ele = subprocess.check_output("curl -s ipinfo.io/%s/geo" % line, shell=True)
     attacker_ele = attacker_ele.decode()
     if "Rate limit exceeded" in attacker_ele:
       print("WARNING: ipinfo look-up allowance exceeded - try later or subscribe to paid service")


### PR DESCRIPTION
- Added root/sudo check
- Added -s to curl command to hide curl's progress in shell

Alternatively, you can implement that by calling the parameter in the main script `fail2ban_analyse.py` you can hide the `curl` output or display it.

Example:
To show `curl` progress output: `fail2ban_analyse.py /var/log all show-curl`
By default it hides the output.

Hope this helps you! :3